### PR TITLE
fix: mark API package as private to prevent publishing

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fiberplane/mcp-gateway-api",
-  "private": false,
+  "private": true,
   "type": "module",
   "version": "0.2.0-next.0",
   "description": "REST API for querying MCP Gateway logs",


### PR DESCRIPTION
The API package is bundled into the CLI binary and should not be published independently to npm. It's already in the changesets ignore list but needs to be marked as private to prevent the CI publish script from attempting to publish it.